### PR TITLE
Optional dependencies for data downloaders

### DIFF
--- a/deepsensor/data/sources.py
+++ b/deepsensor/data/sources.py
@@ -33,7 +33,7 @@ def get_ghcnd_station_data(
     .. note::
         Requires the `scotthosking/get-station-data` repository to be installed
         manually in your Python environment with:
-        `pip install git+https://github.com/scott-hosking/get-station-data.git`
+        ``pip install git+https://github.com/scott-hosking/get-station-data.git``
 
     .. note::
         Example key variable IDs:
@@ -454,6 +454,11 @@ def get_earthenv_auxiliary_data(
     Download global static auxiliary data from EarthEnv into an xarray DataArray.
     See: https://www.earthenv.org/topography
 
+    .. note::
+        Requires the `rioxarray` package to be installed. e.g. via ``pip install rioxarray``.
+        See the ``rioxarray`` pages for more installation options:
+        https://corteva.github.io/rioxarray/stable/installation.html
+    
     .. note::
         This method downloads the data from EarthEnv to disk, then reads it into memory,
         and then deletes the file from disk. This is because EarthEnv does not support

--- a/deepsensor/data/sources.py
+++ b/deepsensor/data/sources.py
@@ -458,7 +458,7 @@ def get_earthenv_auxiliary_data(
         Requires the `rioxarray` package to be installed. e.g. via ``pip install rioxarray``.
         See the ``rioxarray`` pages for more installation options:
         https://corteva.github.io/rioxarray/stable/installation.html
-    
+
     .. note::
         This method downloads the data from EarthEnv to disk, then reads it into memory,
         and then deletes the file from disk. This is because EarthEnv does not support
@@ -508,8 +508,11 @@ def get_earthenv_auxiliary_data(
 
     # Check for rioxarray and raise error if not present
     import importlib.util
+
     if importlib.util.find_spec("rioxarray") is None:
-        raise ImportError("The rioxarray is required to run this function, it was not found. Install with `pip install rioxarray`.")
+        raise ImportError(
+            "The rioxarray is required to run this function, it was not found. Install with `pip install rioxarray`."
+        )
 
     @memory.cache
     def _get_auxiliary_data_cached(

--- a/deepsensor/data/sources.py
+++ b/deepsensor/data/sources.py
@@ -473,8 +473,8 @@ def get_earthenv_auxiliary_data(
         elevation of a cell and the mean elevation of its surrounding landscape. This highlights
         topographic features such as mountains (positive TPI) and valleys (negative TPI).
 
-    .. note::
-        TODO support land cover data: https://www.earthenv.org/landcover
+    .. todo::
+        support land cover data: https://www.earthenv.org/landcover
 
     .. warning::
         If this function is updated, the cache will be invalidated and the data will need

--- a/deepsensor/data/sources.py
+++ b/deepsensor/data/sources.py
@@ -506,6 +506,11 @@ def get_earthenv_auxiliary_data(
         cache_dir = None
     memory = Memory(cache_dir, verbose=0)
 
+    # Check for rioxarray and raise error if not present
+    import importlib.util
+    if importlib.util.find_spec("rioxarray") is None:
+        raise ImportError("The rioxarray is required to run this function, it was not found. Install with `pip install rioxarray`.")
+
     @memory.cache
     def _get_auxiliary_data_cached(
         var_IDs: str,

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -64,12 +64,14 @@ sphinx:
     - 'sphinx.ext.autodoc'
     - 'sphinx.ext.napoleon'
     - 'sphinx.ext.viewcode'
+    - 'sphinx.ext.todo'
   config:
     add_module_names: False
     autodoc_typehints: "none"
     autoclass_content: "class"
     bibtex_reference_style: author_year
     napoleon_use_rtype: False
+    todo_include_todos: True
     intersphinx_mapping:
       python:
         - https://docs.python.org/3

--- a/docs/getting-started/data_requirements.ipynb
+++ b/docs/getting-started/data_requirements.ipynb
@@ -48,7 +48,20 @@
     "* [EarthEnv](https://www.earthenv.org/): EarthEnv elevation and Topographic Position Index (TPI) data at various resolutions (1 km, 5 km, 10 km, 50 km, 100 km)\n",
     "* [GLDAS](https://ldas.gsfc.nasa.gov/gldas/): Global Land Data Assimilation System (GLDAS) 0.25 degree resolution binary land mask\n",
     "\n",
-    "For more details on the data sources, see the API reference for the [data.sources module](../reference/data/sources.rst)."
+    "For more details on the data sources, see the API reference for the [data.sources module](../reference/data/sources.rst).\n",
+    "\n",
+    "`````{note}\n",
+    "Some of the data downloader functions used here require additional dependencies.\n",
+    "To run this yourself you will need to run:\n",
+    "```\n",
+    "pip install rioxarray\n",
+    "```\n",
+    "to install the [`rioxarray`](https://corteva.github.io/rioxarray/stable/) package and\n",
+    "```\n",
+    "pip install git+https://github.com/scott-hosking/get-station-data.git\n",
+    "```\n",
+    "to install the [`get_station_data`](https://github.com/scotthosking/get-station-data) package.\n",
+    "`````\n"
    ],
    "metadata": {
     "collapsed": false

--- a/docs/user-guide/data_processor.ipynb
+++ b/docs/user-guide/data_processor.ipynb
@@ -1,3 +1,4 @@
+
 {
  "cells": [
   {
@@ -15,7 +16,15 @@
     "In DeepSensor, this is achieved with the [`DataProcessor` class](../reference/data/processor.rst).\n",
     "Let's load some environmental data from `deepsensor.data.sources` and see how it works!\n",
     "\n",
-    "Note, to run this yourself you will need to `pip install git+https://github.com/scott-hosking/get-station-data.git`."
+    "`````{note}\n",
+    "Some of the data downloader functions used here require additional dependencies.\n",
+    "To run this yourself you will need to run:\n",
+    "```\n",
+    "pip install rioxarray git+https://github.com/scott-hosking/get-station-data.git`\n",
+    "```\n",
+    "to install the [`rioxarray`](https://corteva.github.io/rioxarray/stable/) package and code from the [`get_station_data`](https://github.com/scotthosking/get-station-data) repository on GitHub.\n",
+    "`````\n",
+    "\n"
    ]
   },
   {

--- a/docs/user-guide/data_processor.ipynb
+++ b/docs/user-guide/data_processor.ipynb
@@ -20,9 +20,13 @@
     "Some of the data downloader functions used here require additional dependencies.\n",
     "To run this yourself you will need to run:\n",
     "```\n",
-    "pip install rioxarray git+https://github.com/scott-hosking/get-station-data.git`\n",
+    "pip install rioxarray\n",
     "```\n",
-    "to install the [`rioxarray`](https://corteva.github.io/rioxarray/stable/) package and code from the [`get_station_data`](https://github.com/scotthosking/get-station-data) repository on GitHub.\n",
+    "to install the [`rioxarray`](https://corteva.github.io/rioxarray/stable/) package and\n",
+    "```\n",
+    "pip install git+https://github.com/scott-hosking/get-station-data.git\n",
+    "```\n",
+    "to install the [`get_station_data`](https://github.com/scotthosking/get-station-data) package.\n",
     "`````\n",
     "\n"
    ]


### PR DESCRIPTION
Relates to #106 and #102

* Adds some more detail to the user guide's data processor page and docstrings for two data downloaders on them needing optional dependencies (or more specifically, non PyPI compatible dependencies for get_station_data).
* Adds a check into `get_earthenv_auxiliary_data` that rioxarray is installed before downloading the data.
* For good measure, adds the sphinx todo exension for displaying todo directives in docstrings.