### PR TITLE
Fix python version in tests (plus additional minor fixes)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: ['3.8', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,14 +18,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Delete huge unnecessary folders, and clean apt cache
-      run: |
-        rm -rf /opt/hostedtoolcache
-        rm -rf /usr/share/dotnet
-        rm -rf /opt/ghc
-        rm -rf "$AGENT_TOOLSDIRECTORY"
-        sudo apt-get clean
-      shell: bash
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
     - name: Print space
       run: df -h
     - name: Install dependencies

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -243,7 +243,7 @@ class DeepSensorModel(ProbabilisticModel):
         aux_at_targets_override: Union[xr.Dataset, xr.DataArray] = None,
         aux_at_targets_override_is_normalised: bool = False,
         resolution_factor: int = 1,
-        pred_params: tuple[str] = ("mean", "std"),
+        pred_params: Tuple[str] = ("mean", "std"),
         n_samples: int = 0,
         ar_sample: bool = False,
         ar_subsample_factor: int = 1,
@@ -274,7 +274,7 @@ class DeepSensorModel(ProbabilisticModel):
                 Whether the `aux_at_targets_override` coords are normalised.
                 If False, the DataProcessor will normalise the coords before passing to model.
                 Default False.
-            pred_params (tuple[str]):
+            pred_params (Tuple[str]):
                 Tuple of prediction parameters to return. The strings refer to methods
                 of the model class which will be called and stored in the Prediction object.
                 Default ("mean", "std").


### PR DESCRIPTION
Whilst looking into #115 I noticed that something funky was going in the CI environment when running tests in which a different python version from the ones specified in the version matrix, using python 3.10 for all of the tests.

This turned out to be because of the step in which space was being cleared, inadvertently deleting the python executable installed by the setup-python action at `/opt/hostedtoolscache`. I've replaced this with a different option using the [`jlumbroso/free-disk-space` ](https://github.com/marketplace/actions/free-disk-space-ubuntu) action for ubuntu runners. Have tested this out over on [my fork](https://github.com/davidwilby/deepsensor) and confirmed that the expected python versions are being used in running tests by tox.

Additionally, this PR:
+ upgrades some deprecated actions versions,
+ Fixes a bug found when running tests with python 3.8 in which the post-3.8 typehint style was being used, resulting in an error. I suggest this fix rather than shifting to the newer style since python 3.8 is still technically in support for the time-being. (Edit: https://pypi.org/project/typing-extensions/ would be another option for this, but maybe in a separate PR)