### PR TITLE
use unittest's `setUpClass` instead of overriding `__init__`

### DIFF
--- a/tests/test_active_learning.py
+++ b/tests/test_active_learning.py
@@ -40,9 +40,7 @@ class TestActiveLearning(unittest.TestCase):
         cls.data_processor = DataProcessor(x1_name="lat", x2_name="lon")
         cls.ds = cls.data_processor(ds_raw)
         # Set up a model with two context sets and two target sets for generality
-        cls.task_loader = TaskLoader(
-            context=[cls.ds, cls.ds], target=[cls.ds, cls.ds]
-        )
+        cls.task_loader = TaskLoader(context=[cls.ds, cls.ds], target=[cls.ds, cls.ds])
         cls.model = ConvNP(
             cls.data_processor,
             cls.task_loader,

--- a/tests/test_active_learning.py
+++ b/tests/test_active_learning.py
@@ -30,33 +30,34 @@ from deepsensor.model.convnp import ConvNP
 
 
 class TestActiveLearning(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
 
         # It's safe to share data between tests because the TaskLoader does not modify data
         ds_raw = xr.tutorial.open_dataset("air_temperature")["air"]
-        self.ds_raw = ds_raw
-        self.data_processor = DataProcessor(x1_name="lat", x2_name="lon")
-        self.ds = self.data_processor(ds_raw)
+        cls.ds_raw = ds_raw
+        cls.data_processor = DataProcessor(x1_name="lat", x2_name="lon")
+        cls.ds = cls.data_processor(ds_raw)
         # Set up a model with two context sets and two target sets for generality
-        self.task_loader = TaskLoader(
-            context=[self.ds, self.ds], target=[self.ds, self.ds]
+        cls.task_loader = TaskLoader(
+            context=[cls.ds, cls.ds], target=[cls.ds, cls.ds]
         )
-        self.model = ConvNP(
-            self.data_processor,
-            self.task_loader,
+        cls.model = ConvNP(
+            cls.data_processor,
+            cls.task_loader,
             unet_channels=(5, 5, 5),
             verbose=False,
         )
 
         # Set up model with aux-at-target data
-        aux_at_targets = self.ds.isel(time=0).drop_vars("time")
-        self.task_loader_with_aux = TaskLoader(
-            context=self.ds, target=self.ds, aux_at_targets=aux_at_targets
+        aux_at_targets = cls.ds.isel(time=0).drop_vars("time")
+        cls.task_loader_with_aux = TaskLoader(
+            context=cls.ds, target=cls.ds, aux_at_targets=aux_at_targets
         )
-        self.model_with_aux = ConvNP(
-            self.data_processor,
-            self.task_loader_with_aux,
+        cls.model_with_aux = ConvNP(
+            cls.data_processor,
+            cls.task_loader_with_aux,
             unet_channels=(5, 5, 5),
             verbose=False,
         )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -51,14 +51,15 @@ class TestModel(unittest.TestCase):
     A test class for the ``ConvNP`` model.
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    @classmethod
+    def setUpClass(cls):
+        # super().__init__(*args, **kwargs)
         # It's safe to share data between tests because the TaskLoader does not modify data
-        self.da = _gen_data_xr()
-        self.df = _gen_data_pandas()
+        cls.da = _gen_data_xr()
+        cls.df = _gen_data_pandas()
 
-        self.dp = DataProcessor()
-        _ = self.dp([self.da, self.df])  # Compute normalisation parameters
+        cls.dp = DataProcessor()
+        _ = cls.dp([cls.da, cls.df])  # Compute normalisation parameters
 
     def _gen_task_loader_call_args(self, n_context, n_target):
         """Generate arguments for TaskLoader.__call__"""

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -11,22 +11,23 @@ from deepsensor.model.convnp import ConvNP
 
 
 class TestPlotting(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
         # It's safe to share data between tests because the TaskLoader does not modify data
         ds_raw = xr.tutorial.open_dataset("air_temperature")
-        self.ds_raw = ds_raw
-        self.data_processor = DataProcessor(x1_name="lat", x2_name="lon")
-        ds = self.data_processor(ds_raw)
-        self.task_loader = TaskLoader(context=ds, target=ds)
-        self.model = ConvNP(
-            self.data_processor,
-            self.task_loader,
+        cls.ds_raw = ds_raw
+        cls.data_processor = DataProcessor(x1_name="lat", x2_name="lon")
+        ds = cls.data_processor(ds_raw)
+        cls.task_loader = TaskLoader(context=ds, target=ds)
+        cls.model = ConvNP(
+            cls.data_processor,
+            cls.task_loader,
             unet_channels=(5, 5, 5),
             verbose=False,
         )
         # Sample a task with 10 random context points
-        self.task = self.task_loader(
+        cls.task = cls.task_loader(
             "2014-12-31", context_sampling=10, target_sampling="all"
         )
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -10,17 +10,18 @@ from deepsensor.model import ConvNP
 
 
 class TestConcatTasks(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
         # It's safe to share data between tests because the TaskLoader does not modify data
         ds_raw = xr.tutorial.open_dataset("air_temperature")
-        self.ds_raw = ds_raw
-        self.data_processor = DataProcessor(x1_name="lat", x2_name="lon")
-        ds = self.data_processor(ds_raw)
-        self.task_loader = TaskLoader(context=ds, target=ds)
-        self.model = ConvNP(
-            self.data_processor,
-            self.task_loader,
+        cls.ds_raw = ds_raw
+        cls.data_processor = DataProcessor(x1_name="lat", x2_name="lon")
+        ds = cls.data_processor(ds_raw)
+        cls.task_loader = TaskLoader(context=ds, target=ds)
+        cls.model = ConvNP(
+            cls.data_processor,
+            cls.task_loader,
             unet_channels=(5, 5, 5),
             verbose=False,
         )

--- a/tests/test_task_loader.py
+++ b/tests/test_task_loader.py
@@ -57,12 +57,12 @@ class TestTaskLoader(unittest.TestCase):
     - Task batching shape as expected
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    @classmethod
+    def setUpClass(cls):
         # It's safe to share data between tests because the TaskLoader does not modify data
-        self.da = _gen_data_xr()
-        self.aux_da = self.da.isel(time=0)
-        self.df = _gen_data_pandas()
+        cls.da = _gen_data_xr()
+        cls.aux_da = cls.da.isel(time=0)
+        cls.df = _gen_data_pandas()
 
     def _gen_task_loader_call_args(self, n_context_sets, n_target_sets):
         """Generate arguments for ``TaskLoader.__call__``."""

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -16,15 +16,16 @@ from deepsensor.data.task import concat_tasks
 
 
 class TestTraining(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def setUpClass(cls):
         # It's safe to share data between tests because the TaskLoader does not modify data
         ds_raw = xr.tutorial.open_dataset("air_temperature")
 
-        self.ds_raw = ds_raw
-        self.data_processor = DataProcessor(x1_name="lat", x2_name="lon")
+        cls.ds_raw = ds_raw
+        cls.data_processor = DataProcessor(x1_name="lat", x2_name="lon")
 
-        self.da = self.data_processor(ds_raw)
+        cls.da = cls.data_processor(ds_raw)
 
     def test_concat_tasks(self):
         tl = TaskLoader(context=self.da, target=self.da)


### PR DESCRIPTION
Hopefully this resolves #115 :crossed_fingers: 

Whilst investigating the issue raised in #115 I noticed a number of issues on which the order/combination of tests run influenced the behaviour.

I can't say that I fully follow the reason behind the pollution between the different test modules but these changes seem to produce the desired behaviour as far as I can tell :shrug: 

[UnitTest recommends](https://docs.python.org/3/library/unittest.html#unittest.TestCase.setUpClass) using the class method `setUpClass` (similar to `setUp` but runs only once for all of the tests in the class)

Have run this locally and all tests pass, let's see what happens on GitHub actions...

**Note** that this branch doesn't include the fixes to the CI testing workflow in #116 so technically the tests on this branch will be running with the runner's OS python installation, not those managed by the python version matrix.