### PR TITLE
Fix astype in coordinates matching when sampling data frames

### DIFF
--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -722,8 +722,8 @@ class TaskLoader:
         elif isinstance(sampling_strat, np.ndarray):
             if df.index.get_level_values("x1").dtype != sampling_strat.dtype:
                 raise InvalidSamplingStrategyError(
-                    f"Passed a numpy coordinate array to sample pandas DataFrame, "
-                    f"but the coordinate array has a different dtype than the DataFrame. "
+                    "Passed a numpy coordinate array to sample pandas DataFrame, "
+                    "but the coordinate array has a different dtype than the DataFrame. "
                     f"Got {sampling_strat.dtype} but expected {df.index.get_level_values('x1').dtype}."
                 )
 
@@ -735,9 +735,11 @@ class TaskLoader:
             # Check that we got all the samples we asked for
             if num_matches != X_c.shape[1]:
                 raise InvalidSamplingStrategyError(
-                    f"Passed a numpy coordinate array to sample pandas DataFrame, "
-                    f"but the DataFrame did not contain all the requested samples. "
-                    f"Requested {X_c.shape[1]} samples but only got {num_matches}."
+                    "Passed a numpy coordinate array to sample pandas DataFrame, "
+                    "but the DataFrame did not contain all the requested samples. "
+                    f"Requested {X_c.shape[1]} samples but only got {num_matches}. "
+                    "If this is unexpected, check that your numpy sampling array matches "
+                    "the DataFrame index values *exactly*."
                 )
 
             Y_c = df[x1match & x2match].values.T

--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -726,23 +726,18 @@ class TaskLoader:
                     "but the coordinate array has a different dtype than the DataFrame. "
                     f"Got {sampling_strat.dtype} but expected {df.index.get_level_values('x1').dtype}."
                 )
-
             X_c = sampling_strat.astype(self.dtype)
-            x1match = np.in1d(df.index.get_level_values("x1"), X_c[0])
-            x2match = np.in1d(df.index.get_level_values("x2"), X_c[1])
-            num_matches = np.sum(x1match & x2match)
-
-            # Check that we got all the samples we asked for
-            if num_matches != X_c.shape[1]:
+            try:
+                Y_c = df.loc[pd.IndexSlice[:, X_c[0], X_c[1]]].values.T
+            except KeyError:
                 raise InvalidSamplingStrategyError(
                     "Passed a numpy coordinate array to sample pandas DataFrame, "
-                    "but the DataFrame did not contain all the requested samples. "
-                    f"Requested {X_c.shape[1]} samples but only got {num_matches}. "
+                    "but the DataFrame did not contain all the requested samples.\n"
+                    f"Indexes: {df.index}\n"
+                    f"Sampling coords: {X_c}\n"
                     "If this is unexpected, check that your numpy sampling array matches "
                     "the DataFrame index values *exactly*."
                 )
-
-            Y_c = df[x1match & x2match].values.T
         else:
             raise InvalidSamplingStrategyError(
                 f"Unknown sampling strategy {sampling_strat}"

--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -720,9 +720,16 @@ class TaskLoader:
             X_c = df.reset_index()[["x1", "x2"]].values.T.astype(self.dtype)
             Y_c = df.values.T
         elif isinstance(sampling_strat, np.ndarray):
+            if df.index.get_level_values("x1").dtype != sampling_strat.dtype:
+                raise InvalidSamplingStrategyError(
+                    f"Passed a numpy coordinate array to sample pandas DataFrame, "
+                    f"but the coordinate array has a different dtype than the DataFrame. "
+                    f"Got {sampling_strat.dtype} but expected {df.index.get_level_values('x1').dtype}."
+                )
+
             X_c = sampling_strat.astype(self.dtype)
-            x1match = np.in1d(df.index.get_level_values("x1").astype(self.dtype), X_c[0])
-            x2match = np.in1d(df.index.get_level_values("x2").astype(self.dtype), X_c[1])
+            x1match = np.in1d(df.index.get_level_values("x1"), X_c[0])
+            x2match = np.in1d(df.index.get_level_values("x2"), X_c[1])
             num_matches = np.sum(x1match & x2match)
 
             # Check that we got all the samples we asked for

--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -678,11 +678,11 @@ class TaskLoader:
         seed: Optional[int] = None,
     ) -> (np.ndarray, np.ndarray):
         """
-        Sample a DataArray according to a given strategy.
+        Sample a DataFrame according to a given strategy.
 
         Args:
             df (:class:`pandas.DataFrame` | :class:`pandas.Series`):
-                DataArray to sample, assumed to be time-sliced for the task
+                Dataframe to sample, assumed to be time-sliced for the task
                 already.
             sampling_strat (str | int | float | :class:`numpy:numpy.ndarray`):
                 Sampling strategy, either "all" or an integer for random grid

--- a/deepsensor/data/loader.py
+++ b/deepsensor/data/loader.py
@@ -721,8 +721,8 @@ class TaskLoader:
             Y_c = df.values.T
         elif isinstance(sampling_strat, np.ndarray):
             X_c = sampling_strat.astype(self.dtype)
-            x1match = np.in1d(df.index.get_level_values("x1"), X_c[0])
-            x2match = np.in1d(df.index.get_level_values("x2"), X_c[1])
+            x1match = np.in1d(df.index.get_level_values("x1").astype(self.dtype), X_c[0])
+            x2match = np.in1d(df.index.get_level_values("x2").astype(self.dtype), X_c[1])
             num_matches = np.sum(x1match & x2match)
 
             # Check that we got all the samples we asked for

--- a/tests/test_task_loader.py
+++ b/tests/test_task_loader.py
@@ -192,6 +192,18 @@ class TestTaskLoader(unittest.TestCase):
                 with self.assertRaises(InvalidSamplingStrategyError):
                     task = tl("2020-01-01", invalid_sampling_strategy)
 
+    def test_different_dtype_when_sampling_offgrid_data_at_specific_numpy_locs(self):
+        """Test different dtype when sampling off-grid data at specific numpy locations."""
+        sampling_strat = np.array([np.linspace(0, 1, 10),np.linspace(0, 1, 10)])
+
+        tl = TaskLoader(
+            context=self.df,
+            target=self.df,
+        )
+
+        # This should not raise an error
+        task = tl("2020-01-01", sampling_strat)
+
     def test_wrong_links(self):
         """Test link indexes out of range."""
         with self.assertRaises(ValueError):

--- a/tests/test_task_loader.py
+++ b/tests/test_task_loader.py
@@ -194,15 +194,20 @@ class TestTaskLoader(unittest.TestCase):
 
     def test_different_dtype_when_sampling_offgrid_data_at_specific_numpy_locs(self):
         """Test different dtype when sampling off-grid data at specific numpy locations."""
-        sampling_strat = np.array([np.linspace(0, 1, 10),np.linspace(0, 1, 10)])
+        sampling_strat = np.array(
+            [np.linspace(0, 1, 10), np.linspace(0, 1, 10)], dtype=np.float16
+        )
 
         tl = TaskLoader(
             context=self.df,
             target=self.df,
         )
 
-        # This should not raise an error
-        task = tl("2020-01-01", sampling_strat)
+        assert sampling_strat.dtype != tl.context[0].index.get_level_values("x1").dtype
+        assert sampling_strat.dtype != tl.context[0].index.get_level_values("x2").dtype
+
+        with self.assertRaises(InvalidSamplingStrategyError):
+            task = tl("2020-01-01", sampling_strat, sampling_strat)
 
     def test_wrong_links(self):
         """Test link indexes out of range."""


### PR DESCRIPTION
The PR fixes the sampling strategy when locations are `np.ndarray`. It also amends the docs of the `sample_df` function.

Fixes #125