### PR TITLE
Bump neuralprocesses version for bernoulli-gamma likelihood

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ rioxarray
 numpy
 dask
 distributed
-neuralprocesses>=0.2.2
+neuralprocesses>=0.2.6
 tensorflow
 tensorflow_probability[tf]
 torch>=2


### PR DESCRIPTION
Failures relating to Bernoulli-Gamma likelihood feature from Neural Processes with versions < 0.2.6