### PR TITLE
Fix forecasting lead times and improve forecasting functionality

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -38,5 +38,5 @@ keywords:
   - neural processes
   - active learning
 license: MIT
-version: 0.3.8
-date-released: '2024-07-28'
+version: 0.4.0
+date-released: '2024-10-20'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ data with neural processes</p>
 
 -----------
 
-[![release](https://img.shields.io/badge/release-v0.3.8-green?logo=github)](https://github.com/alan-turing-institute/deepsensor/releases)
+[![release](https://img.shields.io/badge/release-v0.4.0-green?logo=github)](https://github.com/alan-turing-institute/deepsensor/releases)
 [![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://alan-turing-institute.github.io/deepsensor/)
 ![Tests](https://github.com/alan-turing-institute/deepsensor/actions/workflows/tests.yml/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/alan-turing-institute/deepsensor/badge.svg?branch=main)](https://coveralls.io/github/alan-turing-institute/deepsensor?branch=main)

--- a/deepsensor/eval/__init__.py
+++ b/deepsensor/eval/__init__.py
@@ -1,0 +1,1 @@
+from .metrics import *

--- a/deepsensor/eval/metrics.py
+++ b/deepsensor/eval/metrics.py
@@ -1,0 +1,24 @@
+import xarray as xr
+from deepsensor.model.pred import Prediction
+
+
+def compute_errors(pred: Prediction, target: xr.Dataset) -> xr.Dataset:
+    """
+    Compute errors between predictions and targets.
+
+    Args:
+        pred: Prediction object.
+        target: Target data.
+
+    Returns:
+        xr.Dataset: Dataset of pointwise differences between predictions and targets
+        at the same valid time in the predictions. Note, the difference is positive
+        when the prediction is greater than the target.
+    """
+    errors = {}
+    for var_ID, pred_var in pred.items():
+        target_var = target[var_ID]
+        error = pred_var["mean"] - target_var.sel(time=pred_var.time)
+        error.name = f"{var_ID}"
+        errors[var_ID] = error
+    return xr.Dataset(errors)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = deepsensor
-version = 0.3.8
+version = 0.4.0
 author = Tom R. Andersson
 author_email = tomandersson3@gmail.com
 description = A Python package for modelling xarray and pandas data with neural processes.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -688,7 +688,7 @@ class TestModel(unittest.TestCase):
                 # Check we can compute errors using the valid time coord ('time')
                 errors = pred_var["mean"] - self.da.sel(time=pred_var.time)
                 assert errors.dims == ("lead_time", "init_time", "x1", "x2")
-                assert errors.shape == pred_var.shape
+                assert errors.shape == pred_var["mean"].shape
             elif isinstance(pred_var, pd.DataFrame):
                 # Makes coordinate checking easier by avoiding repeat values
                 pred_var = pred_var.to_xarray().isel(x1=0, x2=0)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -651,8 +651,9 @@ class TestModel(unittest.TestCase):
         """Test that the times returned by a forecasting model are valid."""
         lead_times_days = [1, 2, 3]
         init_date = "2020-01-01"
+        expected_lead_times = [pd.Timedelta(days=lt) for lt in lead_times_days]
         expected_valid_times = [
-            pd.Timestamp(init_date) + pd.DateOffset(days=lt) for lt in lead_times_days
+            pd.Timestamp(init_date) + lt for lt in expected_lead_times
         ]
 
         tl = TaskLoader(
@@ -669,6 +670,9 @@ class TestModel(unittest.TestCase):
         pred = model.predict(task, X_t=self.da)
         np.testing.assert_array_equal(
             pred[self.var_ID]["mean"].time.values, expected_valid_times
+        )
+        np.testing.assert_array_equal(
+            pred[self.var_ID]["mean"].lead_time.values, expected_lead_times
         )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -684,7 +684,12 @@ class TestModel(unittest.TestCase):
 
             pred_var = pred[self.var_ID]
 
-            if isinstance(pred_var, pd.DataFrame):
+            if isinstance(pred_var, xr.Dataset):
+                # Check we can compute errors using the valid time coord ('time')
+                errors = pred_var["mean"] - self.da.sel(time=pred_var.time)
+                assert errors.dims == ("lead_time", "init_time", "x1", "x2")
+                assert errors.shape == pred_var.shape
+            elif isinstance(pred_var, pd.DataFrame):
                 # Makes coordinate checking easier by avoiding repeat values
                 pred_var = pred_var.to_xarray().isel(x1=0, x2=0)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -657,14 +657,19 @@ class TestModel(unittest.TestCase):
 
         tl = TaskLoader(
             context=self.da,
-            target=[self.da,] * len(lead_times_days),
+            target=[
+                self.da,
+            ]
+            * len(lead_times_days),
             target_delta_t=lead_times_days,
             time_freq="D",
         )
         model = ConvNP(self.dp, tl, unet_channels=(5, 5, 5), verbose=False)
         task = tl(init_date, context_sampling=10)
         pred = model.predict(task, X_t=self.da)
-        np.testing.assert_array_equal(pred[self.var_ID]["mean"].time.values, expected_valid_times)
+        np.testing.assert_array_equal(
+            pred[self.var_ID]["mean"].time.values, expected_valid_times
+        )
 
 
 def assert_shape(x, shape: tuple):


### PR DESCRIPTION
This PR improves forecasting functionality in DeepSensor:
1. Fixes a bug where models set up with a `TaskLoader` with `target_delta_t` containing values >0 would have `model.predict` only return the longest lead time (if there ar multiple lead times).
2. Previously, the `time` dim in `model.predict` forecasts would only correspond to the initialisation time, which is confusing. This PR adds an `init_time` and `lead_time` dim alongside a `time` coordinate (which is the valid time of the forecast, which is more intuitive and enables comparison with non-forecast ground truth with a single `time` dim).
3. Adds a convenient `deepsensor.eval.metrics.compute_errors` method which takes the `Prediction` returned by `model.predict` and computes the differences between the `"mean"` entry of model predictions with those in a target dataset for each variable in the `Prediction`, returning an `xarray.Dataset` of errors from which mean statistics can be computed.

Closes https://github.com/alan-turing-institute/deepsensor/issues/130
Addresses one of the desiderata of https://github.com/alan-turing-institute/deepsensor/issues/130