### PR TITLE
Upgrade coveralls action to non-deprecated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Finish Coveralls
-      uses: coverallsapp/github-action@v1
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.github_token }}
         parallel-finished: true


### PR DESCRIPTION
`coverallsapp/github-action@v1` uses a Node version deprecated by GitHub actions.
Upgrading to v2.