### PR TITLE
Couple of numpy-related fixes

### DIFF
--- a/deepsensor/data/utils.py
+++ b/deepsensor/data/utils.py
@@ -91,7 +91,7 @@ def compute_xarray_data_resolution(ds: Union[xr.DataArray, xr.Dataset]) -> float
     """
     x1_res = np.abs(np.mean(np.diff(ds["x1"])))
     x2_res = np.abs(np.mean(np.diff(ds["x2"])))
-    data_resolution = np.min([x1_res, x2_res])
+    data_resolution = float(np.min([x1_res, x2_res]))
     return data_resolution
 
 

--- a/deepsensor/data/utils.py
+++ b/deepsensor/data/utils.py
@@ -91,6 +91,8 @@ def compute_xarray_data_resolution(ds: Union[xr.DataArray, xr.Dataset]) -> float
     """
     x1_res = np.abs(np.mean(np.diff(ds["x1"])))
     x2_res = np.abs(np.mean(np.diff(ds["x2"])))
+
+    # ensure float type, since numpy 2, np.mean returns a numpy float32
     data_resolution = float(np.min([x1_res, x2_res]))
     return data_resolution
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -156,7 +156,7 @@ class TestModel(unittest.TestCase):
             ):
                 task = tl("2020-01-01", context_sampling, target_sampling)
 
-                n_targets = np.product(expected_obs_shape)
+                n_targets = np.prod(expected_obs_shape)
 
                 # Tensors
                 mean = model.mean(task)
@@ -192,7 +192,7 @@ class TestModel(unittest.TestCase):
                     )
 
                 if likelihood in ["cnp", "gnp"]:
-                    n_target_dims = np.product(tl.target_dims)
+                    n_target_dims = np.prod(tl.target_dims)
                     assert_shape(
                         model.covariance(task),
                         (


### PR DESCRIPTION
## :pencil: Description
We have a few tests routinely failing at the moment for a handful of reasons mostly relating to numpy 2.

One such error is due to DeepSensor's dependency stheno not yet pinning the version of fdm which repairs some of the numpy compatibility bugs. I've raised a PR in that project here: https://github.com/wesselb/stheno/pull/27

In this PR there are a couple of corrections to alleviate test failures:
1. Use of `np.product` in some tests, this was changed in something like numpy 1.16 to `np.prod`.
2. The type of `encoder_scales` was being set to a numpy float32 with numpy 2 (possible relating to https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion) which was causing the saving and loading test to fail. I've added an `int()` but unsure if this is appropriate/ideal, though all of the tests pass locally.


## :white_check_mark: Checklist before requesting a review
(See the contributing guide for more details on these steps.)
- [x] I have installed developer dependencies with `pip install -r requirements/requirements.dev.txt` and running `pre-commit install` (or alternatively, manually running `ruff format` before commiting)

If changing or adding source code:
- [x] tests are included and are passing (run `pytest`).
- [ ] ~~documentation is included or updated as relevant, including docstrings.~~
