### PR TITLE
Use numpy 2-compatible neural processes version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@ rioxarray
 numpy
 dask
 distributed
-neuralprocesses>=0.2.6
+neuralprocesses>=0.2.7
 tensorflow
 tensorflow_probability[tf]
 torch>=2

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.htm
 include_package_data = True
 python_requires = >=3.8
 install_requires =
-    neuralprocesses
+    neuralprocesses>=0.2.7
     backends-matrix
     backends
     numpy


### PR DESCRIPTION
## :pencil: Description
There were one or two numpy 2 fixes required in `fdm` which is a dependency of `stheno` which is a dependency of `neuralprocesses` which I've fixed and the versions have now percolated up to DeepSensor thanks to Wessel.

This PR makes sure we actually use all of these numpy 2-compatible packages.

## :white_check_mark: Checklist before requesting a review
(See the contributing guide for more details on these steps.)
- [x] I have installed developer dependencies with `pip install -r requirements/requirements.dev.txt` and running `pre-commit install` (or alternatively, manually running `ruff format` before commiting)

If changing or adding source code:
- [ ] tests are included and are passing (run `pytest`).
- [ ] documentation is included or updated as relevant, including docstrings.

If changing or adding documentation:
- [ ] docs build successfully (`jupyter-book build docs --all`) and the changes look good from a manual inspection of the HTML in `docs/_build/html/`.
