### PR TITLE
Various docs fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,8 @@ jobs:
     docs:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v2
+            - uses: actions/checkout@v4
+            - uses: actions/setup-python@v5
               with:
                 python-version: 3.11
             - uses: nikeee/setup-pandoc@v1
@@ -18,7 +18,7 @@ jobs:
             - name: "Run jupyterbook"
               run: jupyter-book build docs --all
             - name: "Deploy"
-              uses: peaceiris/actions-gh-pages@v3
+              uses: peaceiris/actions-gh-pages@v4
               if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/docs') }}
               with:
                     publish_branch: gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
             - name: "Upgrade pip"
               run: pip install --upgrade pip
             - name: "Install dependencies"
-              run: pip install .[docs]
+              run: pip install -e .[docs]
             - name: "Run jupyterbook"
               run: jupyter-book build docs --all
             - name: "Deploy"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -40,7 +40,7 @@ This method will create a `DeepSensor` directory on your machine which will cont
 
 ```{note}
 If you intend on contributing to the source code of DeepSensor, install DeepSensor with its development dependencies using
-````{bash}
+````bash
 pip install -v -e .[dev]
 ````
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ docs = [
     "jupyter-book",
     "matplotlib",
     "numpy",
+    "sphinx",
 ]
 testing = [
     "mypy",


### PR DESCRIPTION
Resolves #154 

This seems to have been caused by the changes to the docs workflow in #137 where I stopped using an editable install of the package.

In addition this PR makes some extra docs fixes I spotted.

@tom-andersson - jupyter-book was pinned to 0.15.1 previously, though I seem to have removed that pinning unintentionally in the move to pyproject.toml - are you aware of anything that breaks under jupyter-book v 1? I've been running it locally and it seems to work fine as far as I can tell.