### PR TITLE
Constrain lab/backends version due to fix in plum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "backends",
+    "backends>=1.7.0",
     "backends-matrix",
     "dask",
     "distributed",


### PR DESCRIPTION
lab/backends constrained to version >= 1.7.0 due to fixes in beartype/plum in version 2.5.7