### PR TITLE
use latest ubuntu image in actions; 20.04 now deprecated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
   finish:
     name: Finish Coveralls
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Finish Coveralls
       uses: coverallsapp/github-action@v2


### PR DESCRIPTION
Tests actions were failing at the `finish` stage which was using `ubuntu-20.04` base image, which is now deprecated: https://github.com/actions/runner-images/issues/11101